### PR TITLE
Add npm release-age guardrail

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7


### PR DESCRIPTION
Adds a 7-day release-age delay for npm installs.