### PR TITLE
chore: harden npm installs

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,4 @@
+ignore-scripts=true
+strict-peer-deps=true
+
 min-release-age=7

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,5 @@
+# Lifecycle scripts are disabled for supply-chain hardening.
+# If you need local Husky hooks, run `npm run prepare` explicitly after install.
 ignore-scripts=true
 strict-peer-deps=true
 


### PR DESCRIPTION
Hardens npm-based CI/install behavior:

- enables `ignore-scripts=true`
- keeps `min-release-age=7`
- enables `strict-peer-deps=true`
- updates GitHub Actions Node.js checks to Node 24 where applicable
- updates existing npm package-manager/engine pins to npm 11 where present

Validation: `git diff --check`.
